### PR TITLE
move validation of the wlstScriptDirectory parameter after skipTest

### DIFF
--- a/src/main/java/io/rhpatrick/mojo/wlstTest/WLSTUnitTestMojo.java
+++ b/src/main/java/io/rhpatrick/mojo/wlstTest/WLSTUnitTestMojo.java
@@ -117,6 +117,8 @@ public class WLSTUnitTestMojo extends AbstractMojo {
 
     private static final String WLST_TEST_DEBUG_PROPERTY_NAME = "wlst.test.plugin.debug";
 
+    private static final String WLST_DIR_NOT_SET = "NOT-SET";
+
     @Parameter(defaultValue = "${project}", required = true, readonly = true)
     private MavenProject mavenProject;
 
@@ -197,7 +199,7 @@ public class WLSTUnitTestMojo extends AbstractMojo {
     /**
      * The directory where wlst.sh/wlst.cmd is located.
      */
-    @Parameter(property = "wlstScriptDirectory", required = true)
+    @Parameter(property = "wlstScriptDirectory", required = true, defaultValue = WLST_DIR_NOT_SET)
     private File wlstScriptDirectory;
 
     /**
@@ -224,6 +226,7 @@ public class WLSTUnitTestMojo extends AbstractMojo {
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         if (skipTests) {
+            getLog().info(getMessage("WLSTTEST-018"));
             return;
         } else if (getLog().isDebugEnabled()) {
             isDebug = true;
@@ -265,7 +268,7 @@ public class WLSTUnitTestMojo extends AbstractMojo {
         }
 
         String argName = "wlstScriptDirectory";
-        if (wlstScriptDirectory == null) {
+        if (wlstScriptDirectory == null || WLST_DIR_NOT_SET.equals(wlstScriptDirectory.getName())) {
             throw new MojoExecutionException(getMessage("WLSTTEST-004", argName));
         } else if (!wlstScriptDirectory.isDirectory()) {
             throw new MojoExecutionException(getMessage("WLSTTEST-005", argName,

--- a/src/main/resources/io/rhpatrick/mojo/wlstTest/WLSTTestBundle.properties
+++ b/src/main/resources/io/rhpatrick/mojo/wlstTest/WLSTTestBundle.properties
@@ -33,3 +33,4 @@ WLSTTEST-014=Failed to get the tests driver script from the plugin JAR
 WLSTTEST-015=Failed to write the tests driver script to {0}: {1}
 WLSTTEST-016=Unable to close the tests driver input stream: {0}
 WLSTTEST-017=The environment variable {0} must be set in {1} parameter instead of as an environment variable
+WLSTTEST-018=Tests are skipped.


### PR DESCRIPTION
move validation of the wlstScriptDirectory parameter after skipTest decision to simplify user experience when "not a developer".