### PR TITLE
Added support for Jython 2.7.1 (WLS 14.1.1)

### DIFF
--- a/src/main/resources/io/rhpatrick/mojo/wlstTest/_wlst_test_driver.py
+++ b/src/main/resources/io/rhpatrick/mojo/wlstTest/_wlst_test_driver.py
@@ -102,5 +102,5 @@ def main():
     if not result.wasSuccessful():
         sys.exit(2)
 
-if __name__ == "main":
+if __name__ == "main" or __name__ == "__main__":
     main()


### PR DESCRIPTION
The behavior of __name__ has changed from Jython 2.2 to 2.7.  The value is no longer "main", but "__main__".  Changed the test script runner to accept either 2.2 or 2.7 values for __name__.